### PR TITLE
dotenv package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 **NOTE: This project is still under active development and things will break!**
 
 # celigo-cli
-Celigo Cli allows you to interact with the celigo platform, through your terminal
+Celigo Cli allows you to interact with the [Celigo Platform](https://integrator.io/), through your
+terminal
 
 ## API Key
-Your API Key is read from the following locations in order:
-1. `.env` file in the current directory.
-2. `CELIGO_API_KEY` environment variable.
+You will need to get your api key from Celigo. You can do this by:
+1. Going to [https://integrator.io/accesstokens](https://integrator.io/accesstokens)
+2. Click on "Create API token" in the upper right
+3. Fill in a Name
+4. For Auto purge token select Never
+5. For scope select Full.
+6. Click Save
 
+After receiving your api key, you can use by setting in your environment variables with the name
+`CELIGO_API_KEY`, or using a `.env` file.
 
-## Example .env file
+### Example .env file
 ```text
-a530749681df4d32a5fcc65a166c3da0
+CELIGO_API_KEY=a630749681df4d32a5fcc65a166c3da0
 ```
 
 ## TODO

--- a/celigo-cli.go
+++ b/celigo-cli.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Phandal/celigo-cli/celigo"
+	"github.com/Phandal/celigo-cli/dotenv"
 )
 
 func printError(name string, err error) {
@@ -13,6 +14,8 @@ func printError(name string, err error) {
 
 func main() {
 	programName := os.Args[0]
+	// TODO: Allow the user to specify and environment file
+	dotenv.Parse("")
 
 	cmd, err := celigo.NewCommand(os.Args)
 	if err != nil {

--- a/celigo/client.go
+++ b/celigo/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 )
 
 const baseUrl = "https://api.integrator.io/v1"
@@ -30,36 +29,14 @@ type response struct {
 	Message string `json:"message"`
 }
 
-func getApiKey() (string, error) {
-	_, err := os.Stat(envFile)
-	if err == nil {
-		file, err := os.Open(envFile)
-		if err != nil {
-			return "", err
-		}
-		contents, err := io.ReadAll(file)
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(string(contents)), nil
-	} else {
-		return os.Getenv(celigoCliEnvKey), nil
-	}
-}
-
 func apiKey() (string, error) {
-	if memoizedApiKey == "" {
-		key, err := getApiKey()
-		if err != nil {
-			return "", err
-		}
-		memoizedApiKey = key
-	}
+	apiKey := os.Getenv("CELIGO_API_KEY")
 
-	if len(memoizedApiKey) == 0 {
+	if len(apiKey) == 0 {
 		return "", errors.New("missing CELIGO_API_KEY")
 	}
-	return memoizedApiKey, nil
+
+	return apiKey, nil
 }
 
 func buildRequest(method string, url string, body *bytes.Buffer) (*http.Request, error) {

--- a/dotenv/.env_test
+++ b/dotenv/.env_test
@@ -1,0 +1,2 @@
+TEST_KEY=new_value
+QUOTE_KEY="quote value"

--- a/dotenv/dotenv.go
+++ b/dotenv/dotenv.go
@@ -1,0 +1,39 @@
+package dotenv
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+)
+
+func Parse(filepath string) {
+	envPath := "./.env"
+
+	if filepath != "" {
+		envPath = filepath
+	}
+
+	os.Setenv("CELIGO_CLI_DOTENV_PATH", envPath)
+
+	fd, err := os.Open(envPath)
+	if err != nil {
+		return
+	}
+
+	contents, err := io.ReadAll(fd)
+	if err != nil {
+		return
+	}
+
+	lines := bytes.Split(contents, []byte{'\n'})
+
+	for _, line := range lines {
+		parts := bytes.Split(line, []byte{'='})
+		if len(parts) != 2 {
+			return
+		}
+
+		os.Setenv(string(parts[0]), strings.Trim(string(parts[1]), "\""))
+	}
+}

--- a/dotenv/dotenv_test.go
+++ b/dotenv/dotenv_test.go
@@ -1,0 +1,23 @@
+package dotenv
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	Parse("./.env_test")
+	envFile := os.Getenv("CELIGO_CLI_DOTENV_PATH")
+
+	if envFile != "./.env_test" {
+		t.Fatalf("Failed to set CELIGO_CLI_DOTENV_PATH")
+	}
+
+	if os.Getenv("TEST_KEY") != "new_value" {
+		t.Fatalf("Failed to set environment variables with dotenv")
+	}
+
+	if os.Getenv("QUOTE_KEY") != "quote value" {
+		t.Fatalf("Failed to set quoted environment variables with dotenv")
+	}
+}


### PR DESCRIPTION
Before this package the script was using a hacky solution to get environment variables from a file labeled ".env" in the current directory. It would then read this file and expect there to only be one line with just the api key on it. This did not fit the format that mainstream projects use for ".env" files.

There is now a package called "dotenv". It contains a Parse method that takes a filepath to read and set environment variables from. The filepath can be an empty string in which case it is defaulted to "./.env". The format of the file is {KEY}={VALUE}. Where 
- {KEY} is the name of the environment variable you would like to set
- {VALUE} is the value of the environment variable.

Note if the VALUE contains whitespace, you will need to wrap it in double quotes(").